### PR TITLE
support multiline soql templates

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -340,22 +340,22 @@ class Client {
   /**
    * Quotes and interpolates parameter values into an SOQL template.
    *
+   * Note, SOQL statements are expected to be a single line,
+   *  so newlines in the template will be removed.
+   * If you need a newline (e.g., in a string value), you should pass it as a parameter.
+   *
    * @param string $template SOQL template with value {tokens}
    * @param array $parameters Parameter token:value map
    * @throws UsageException On error
    * @return string Interpolated SOQL on success
    */
   protected function prepare(string $template, array $parameters) : string {
-    if (! empty($parameters)) {
-      $replacements = [];
-      foreach ($parameters as $field => $value) {
-        $replacements["{{$field}}"] = $this->quote($value);
-      }
-
-      $template = strtr($template, $replacements);
+    $replacements = ["\n" => ""];
+    foreach ($parameters as $field => $value) {
+      $replacements["{{$field}}"] = $this->quote($value);
     }
 
-    return $template;
+    return strtr($template, $replacements);
   }
 
   /**
@@ -377,7 +377,7 @@ class Client {
           );
         }
 
-        return "\"" . strtr($value, self::ESCAPE_MAP) . "\"";
+        return "'" . strtr($value, self::ESCAPE_MAP) . "'";
       case self::TYPE_INTEGER:
         $integer = filter_var($value, FILTER_VALIDATE_INT);
         if ($integer === false) {

--- a/tests/QueryTest.php
+++ b/tests/QueryTest.php
@@ -139,6 +139,12 @@ class QueryTest extends SalesforceApiTestCase {
         ["name" => "O'Brien\n\r\t\x07\f\"\\"],
         "SELECT Id, Name FROM Example WHERE Name!='O\'Brien\\n\\r\\t\\b\\f\\\"\\\\' LIMIT 100",
         $response
+      ],
+      "multiline query" => [
+        "SELECT Id, Name\n FROM Example\n WHERE Name='Bob'\n LIMIT 100",
+        [],
+        "SELECT Id, Name FROM Example WHERE Name='Bob' LIMIT 100",
+        $response
       ]
     ];
   }


### PR DESCRIPTION
This is for more convenient formatting of SOQL templates, e.g., using heredocs. 
Especially for long queries, allowing for multiple lines can make queries easier to comprehend and reduce potential escaping mistakes.

Entirely coincidentally, also fixes an escaping mistake in Client->quote().